### PR TITLE
Allow taking serial device from command line

### DIFF
--- a/mastech.py
+++ b/mastech.py
@@ -14,7 +14,7 @@
 # @date: Aug 2013
 
 import serial
-import os
+import glob
 import sys
 from datetime import datetime
 from bitarray import bitarray
@@ -23,15 +23,22 @@ from bitarray import bitarray
 # works in Linux and Mac, should be modified
 # for Windows use
 def get_serial_port_name():
-	tty_str = '/dev/' + os.popen("ls /dev/ | grep -E 'tty(\.usb|USB)' | head -1").read().strip()	
-	return tty_str
+	names = glob.glob('/dev/ttyusb*') + glob.glob('/dev/ttyUSB*')
+	if len(names) == 0:
+		print 'No serial port found!'
+		sys.exit(1)
+	elif len(names) > 1:
+		print 'More than one serial port found: ',
+		for name in names:
+			print name,
+		print
+	return names[0]
 
 # Gets a name for the serial port (if not specified)
 # and creates the serial port
-def get_serial_port(name=''):
-	if name == '':
+def get_serial_port(name=None):
+	if name is None:
 		name = get_serial_port_name()
-		assert name != '', 'No serial port found'
 		print "Automatically selecting %s as serial port" % name
 	s = serial.Serial(name, 
 					  baudrate     = 2400, 

--- a/mastech.py
+++ b/mastech.py
@@ -134,14 +134,17 @@ def parse_data(line):
 		print "Couldn't parse line"
 		print str(e)
 	
-def run(serial_port = None):
+def run(serial_port = None, name = None):
 	if serial_port == None:
-		serial_port = get_serial_port()
+		serial_port = get_serial_port(name=name)
 	safe_open(serial_port)
 	while True:
 		parse_data(serial_port.read(14))
 
 print "Starting Mastech MS8226 DMM parser"
-run()
+if len(sys.argv) > 1:
+    run(name=sys.argv[1])
+else:
+    run()
 serial_port.close()
 print "Exiting"


### PR DESCRIPTION
I usually have several usb to serial devices connected and need a way to tell the application what port to use.
