### PR TITLE
increased timeout to avout 'Bad line' messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ The following models are reported to work with this script:
  - MS8226T
  - TekPower TP4000ZC
  - Voltcraft VC-820
+ - Voltcraft VC-820-1
 
 ### Dependencies ###
 
-To run, please install the python libraries `serial` and `bitarray` (try with `pip install serial bitarray`).
+To run, please install the python libraries `pyserial` and `bitarray` (try with `pip install pyserial bitarray`).
 
 Note: Using in Mac OS X? Check [here](http://stackoverflow.com/questions/22313407/clang-error-unknown-argument-mno-fused-madd-python-package-installation-fa) if you're having trouble building bitarray.
 

--- a/dmm-parser.py
+++ b/dmm-parser.py
@@ -45,7 +45,7 @@ def get_serial_port(name=None):
 					  bytesize     = serial.EIGHTBITS,
 					  parity       = serial.PARITY_NONE,
 					  stopbits     = serial.STOPBITS_ONE,
-					  timeout      = 0.2)
+					  timeout      = 0.23)
 	return s
 
 def safe_open(serial_port):


### PR DESCRIPTION
Tested with a VC820-1, the Voltage measurements delivered clearly about 3 measurements a second. With the uA and mA measurements the following "Bad line" messages appear regularly.

<pre>
$ sudo ./dmm-parser.py
Starting Mastech MS8226 DMM parser
Automatically selecting /dev/ttyUSB0 as serial port
[21:19:13.9] 06.76 mA
Bad line (l=2)
Bad line (l=12)
[21:19:14.8] 06.42 mA
Bad line (l=2)
Bad line (l=12)
[21:19:15.7] 06.76 mA
Bad line (l=2)
Bad line (l=12)
[21:19:16.6] 06.72 mA
</pre>

As it shows, the two "Bad line" length sums up to the length of one data line (14 byte). Analysing the situation, the timeout of the serial port was set to 0.2 which seems to be to short for the VC820-1 to deliver the data. A increase of the timeout to 0.23 resolved the situation. 

It could observed that the V data is delivered faster / more often (every 0.34 - 0.36) then the uA / mA measurements (every 0.44 - 0.45). based on that timing, the transmission was interrupted by the timeout. Increasing to 0.23 would cover up to 0.46 between measurements.

